### PR TITLE
fix: remove title and subtitle from header while preserving theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark/light theme">
                     <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -140,31 +140,12 @@ header {
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     max-width: 1200px;
     margin: 0 auto;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -852,7 +833,7 @@ details[open] .suggested-header::before {
     .header-content {
         padding: 0;
         flex-direction: row;
-        justify-content: space-between;
+        justify-content: flex-end;
         align-items: center;
     }
     
@@ -865,9 +846,6 @@ details[open] .suggested-header::before {
         padding: 1rem;
     }
     
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
Removes the header title and subtitle while preserving the theme toggle functionality, making the header look like it did before the text elements were added.

**Changes:**
- Remove header-text div containing h1 title and subtitle
- Keep theme toggle button functionality intact
- Update header layout to right-align theme toggle
- Clean up unused CSS rules for removed elements
- Update responsive styles to maintain proper alignment

Fixes #6

Generated with [Claude Code](https://claude.ai/code)